### PR TITLE
Fixed asset precompilation bug

### DIFF
--- a/capistrano-exfel.gemspec
+++ b/capistrano-exfel.gemspec
@@ -7,11 +7,11 @@ require 'capistrano/exfel/version'
 Gem::Specification.new do |spec|
   spec.name          = 'capistrano-exfel'
   spec.version       = Capistrano::Exfel::VERSION
-  spec.authors       = ['Luis Maia']
-  spec.email         = ['luisgoncalo.maia@gmail.com']
+  spec.authors       = ['Luis Maia','Maurizio Manetti']
+  spec.email         = %w[luisgoncalo.maia@gmail.com maurizio.manetti@xfel.eu]
   spec.summary       = 'Deploy Ruby on Rails 4 Applications in EXFEL Virtual Machines'
-  spec.description   = 'Deployment of Ruby on Rails 4 Applications in EXFEL Virtual Machines ' \
-                        '(Scientific Linux + Apache + RVM + Phusion Passenger) using Capistrano3 and Kerberos'
+  spec.description   = 'Deployment of Ruby on Rails Applications in EXFEL Virtual Machines ' \
+                        '(Scientific Linux / CentOS 7 + Apache + RVM + Phusion Passenger) using Capistrano3 and LDAP'
   spec.homepage      = ''
   spec.license       = 'MIT'
 

--- a/lib/capistrano/exfel/co7.rb
+++ b/lib/capistrano/exfel/co7.rb
@@ -7,20 +7,13 @@ require 'capistrano/deploy'
 # Includes tasks from other gems included in your Gemfile
 require 'capistrano/rvm'
 
-case fetch(:rails_env).to_s
-when 'production', 'test'
-  # We're going to use the full capistrano/rails since
-  # it includes the asset compilation, DB migrations and bundler
-  require 'capistrano/rails'
-else # when 'development'
-  # we avoid asset precompilation in dev environment
-  require 'capistrano/bundler'
-  require 'capistrano/rails/migrations'
-end
+# Includes tasks for rails
+require 'capistrano/rails'
 
 load File.expand_path('../../tasks/apache.rake', __FILE__)
 load File.expand_path('../../tasks/apache_co7.rake', __FILE__)
 load File.expand_path('../../tasks/app_home.rake', __FILE__)
+load File.expand_path('../../tasks/assets.rake', __FILE__)
 load File.expand_path('../../tasks/application.rake', __FILE__)
 load File.expand_path('../../tasks/database.rake', __FILE__)
 load File.expand_path('../../tasks/secrets.rake', __FILE__)

--- a/lib/capistrano/exfel/sl6.rb
+++ b/lib/capistrano/exfel/sl6.rb
@@ -7,20 +7,13 @@ require 'capistrano/deploy'
 # Includes tasks from other gems included in your Gemfile
 require 'capistrano/rvm'
 
-case fetch(:rails_env).to_s
-when 'production', 'test'
-  # We're going to use the full capistrano/rails since
-  # it includes the asset compilation, DB migrations and bundler
-  require 'capistrano/rails'
-else # when 'development'
-  # we avoid asset precompilation in dev environment
-  require 'capistrano/bundler'
-  require 'capistrano/rails/migrations'
-end
+# Includes tasks for rails
+require 'capistrano/rails'
 
 load File.expand_path('../../tasks/apache.rake', __FILE__)
 load File.expand_path('../../tasks/apache_sl6.rake', __FILE__)
 load File.expand_path('../../tasks/app_home.rake', __FILE__)
+load File.expand_path('../../tasks/assets.rake', __FILE__)
 load File.expand_path('../../tasks/application.rake', __FILE__)
 load File.expand_path('../../tasks/database.rake', __FILE__)
 load File.expand_path('../../tasks/secrets.rake', __FILE__)

--- a/lib/capistrano/recipes/config/secrets_example.yml
+++ b/lib/capistrano/recipes/config/secrets_example.yml
@@ -77,7 +77,7 @@ defaults: &defaults
   # 2) It's API and SECRET (or TITLE) is not Blank
   #
   # active_providers: ['kerberos', 'twitter', 'google_oauth2', 'linkedin', 'facebook', 'github']
-  active_providers: ['kerberos']
+  active_providers: ['ldap']
   #
   twitter_app_id: ""
   twitter_app_secret: ""
@@ -90,6 +90,17 @@ defaults: &defaults
   github_app_id: ""
   github_app_secret: ""
   kerberos_title: 'XFEL'
+  ldap_title: 'European-XFEL (LDAP)'
+  ldap:
+    host: 'it-ldap-slave.desy.de'
+    port: 1636
+    users_base_dn: 'ou=people,ou=RGY,o=DESY,c=DE'
+    groups_base_dn: 'ou=group,ou=RGY,o=DESY,c=DE'
+    user_id: 'uid'
+    ssl: true
+    encryption: # This configuration is only taken into account if 'ssl' is true!
+      method: :simple_tls # Default if nil: simple_tls
+      tls_options: '' # Default if nil: nil
 
 #
 development:

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -1,0 +1,20 @@
+# avoid asset precompilation in dev environment
+
+Rake::Task['deploy:assets:precompile'].clear_actions
+namespace :deploy do
+  namespace :assets do
+    task :precompile do
+      on release_roles(fetch(:assets_roles)) do
+        within release_path do
+          with rails_env: fetch(:rails_env), rails_groups: fetch(:rails_assets_groups) do
+            if %w[production test].include?(fetch(:rails_env).to_s)
+              execute :rake, 'assets:precompile'
+            else
+              info 'Skipping asset pre-compilation in dev environment'
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Looking at it afterwards, the bug was quite obvious. We do not (yet) have access to "rails_env" in the required file (co7.rb or sl6.rb) but only in the task. So basically the deploy:asset:precompile task need to be overridden explicitly.
I took the freedom to add myself in the list of the authors :)