### PR TITLE
Fixed skipping asset precompilation 

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -1,20 +1,11 @@
 # avoid asset precompilation in dev environment
 
-Rake::Task['deploy:assets:precompile'].clear_actions
+Rake::Task['deploy:compile_assets'].clear_actions
 namespace :deploy do
-  namespace :assets do
-    task :precompile do
-      on release_roles(fetch(:assets_roles)) do
-        within release_path do
-          with rails_env: fetch(:rails_env), rails_groups: fetch(:rails_assets_groups) do
-            if %w[production test].include?(fetch(:rails_env).to_s)
-              execute :rake, 'assets:precompile'
-            else
-              info 'Skipping asset pre-compilation in dev environment'
-            end
-          end
-        end
-      end
+  task :compile_assets => [:set_rails_env] do
+    if %w[production test].include?(fetch(:rails_env).to_s)
+      invoke 'deploy:assets:precompile'
+      invoke 'deploy:assets:backup_manifest'
     end
   end
 end


### PR DESCRIPTION
Task "compile_assets" has to be skipped as a whole